### PR TITLE
fixed forward slash with wildcard bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ var cssGlobbingPlugin = function(options) {
             result += '@import ' + prefix + foundFilename + suffix + ';\n';
           });
         } else {
-          result = '/* No files to import found in ' + filePattern + ' */';
+          result = '/* No files to import found in ' + filePattern.replace(/\//g,'\//') + ' */';
         }
       }
 

--- a/test/main.js
+++ b/test/main.js
@@ -245,7 +245,7 @@ describe('gulp-css-globbing', function() {
       globber.once('data', function(file) {
         file.isBuffer().should.be.true;
 
-        String(file.contents).should.containEql("/* No files to import found in non-existent/**/*.css */");
+        String(file.contents).should.containEql("/* No files to import found in ..//**//*.scss */");
       });
     });
 


### PR DESCRIPTION
Hi @jsahlen 

I found a bug where using a wildcard with a forward slash was causing an error where it would cancel out the commenting for the line when no scss files were found.

For instance. Say I was using this wildcard statement for my globbing:

```
globBlockContents: '../**/*.scss'
```

The result inside of my main .scss file would then come out like this:

```css
// cssGlobbingBegin
/* No files to import found in ../**/*.scss */
// cssGlobbingEnd
```

The forward-slash+asterisk combo before .scss was ending the comment, which then messes up the import section causing an error when compass attempted to compile the file:

```
    error app/styles/styles.scss (Line 8: Invalid CSS after "*.scss */": expected identifier, was "// cssGlobbingEnd")

Compilation failed in 1 files.

```

I added the simple .replace() pattern in to comment out forward slashes.

thanks,
Scott