### PR TITLE
Inline patched version of vinyl-map

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var gutil = require('gulp-util');
 var glob = require('glob');
-var map = require('vinyl-map');
+var map = require('./lib/vinyl-map');
 
 var path = require('path');
 

--- a/lib/vinyl-map.js
+++ b/lib/vinyl-map.js
@@ -1,0 +1,64 @@
+var through = require('through2')
+var from    = require('new-from')
+var bl      = require('bl')
+
+module.exports = map
+
+function map(fn) {
+  var done = null
+  var pending = 0
+  var stream
+
+  return stream = through.obj(write, flush)
+
+  function write(file, _, next) {
+    if (typeof file !== 'object') return
+    if (!('contents' in file)) return push(file, next)
+
+    if (file.isNull()) return push(file, next)
+    if (file.isBuffer()) return map(file, next)
+
+    // should be a stream by
+    // this point...
+    pending++
+    file.contents.pipe(bl(function(err, result) {
+      if (err) return stream.emit('error', err)
+      map(file, next, result)
+      check(--pending)
+    }))
+  }
+
+  function map(file, next, contents) {
+    file = file.clone()
+    contents = arguments.length < 3
+      ? file.contents
+      : contents
+
+    try {
+      var mapped = fn(contents, file.path)
+    } catch(err) {
+      return stream.emit('error', err)
+    }
+
+    if (mapped === undefined) mapped = contents
+    if (file.isBuffer()) file.contents = new Buffer(mapped)
+    if (file.isStream()) file.contents = from([mapped])
+
+    push(file, next)
+  }
+
+  function push(file, next) {
+    stream.push(file)
+    next()
+  }
+
+  function flush(cb) {
+    check(done = cb)
+  }
+
+  function check() {
+    if (!pending && done) {
+      done();
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
   },
   "main": "index.js",
   "dependencies": {
+    "bl": "^0.9.4",
     "glob": "^4.0.5",
     "gulp-util": "^3.0.0",
-    "vinyl-map": "^1.0.1"
+    "new-from": "0.0.3",
+    "through2": "^0.6.3"
   },
   "devDependencies": {
     "event-stream": "^3.1.7",


### PR DESCRIPTION
`vinyl-map` has an issue with prematurely ending the stream when processing a large number of files. This is currently causing an issue for our use case as we are processing a large number of sass files. To fix this, I have inlined the patched version of `vinyl-map` that was proposed [here](https://github.com/hughsk/vinyl-map/pull/6).