### PR TITLE
Fixed a bug on Windows with wrong slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ var cssGlobbingPlugin = function(options) {
               foundFilename = foundFilename.replace(/^_/,'');
             }
 
-            foundFilePath = path.join(foundFileDirname,foundFilename);
+            foundFilePath = path.join(foundFileDirname,foundFilename).replace(new RegExp('\\' + path.sep, 'g'), '/');
 
             files.push(foundFilePath);
           }


### PR DESCRIPTION
Right now there is a bug while running this with gulp on Windows - imports file paths are getting the wrong slash (backslash instead of forward slash) this is because `path.join()` default separator on Windows is `\\`.
This simple fix takes care of it.